### PR TITLE
Fix sequence note layering

### DIFF
--- a/src/converter/types/sequence.ts
+++ b/src/converter/types/sequence.ts
@@ -21,6 +21,7 @@ export const sequenceToDrawnixConvertor = new GraphConverter({
   converter: (chart: Sequence, config: DrawnixConfig) => {
     const elements: PlaitElement[] = [];
     const activations: PlaitElement[] = [];
+    const notes: PlaitElement[] = [];
     const mermaidGroupIdToElementMap: Record<string, PlaitGroup> = {};
     Object.values(chart.nodes).forEach((node) => {
       if (!node || !node.length) {
@@ -59,6 +60,11 @@ export const sequenceToDrawnixConvertor = new GraphConverter({
         plaitElement.origin = element;
         if (element.type === "rectangle" && element?.subtype === "activation") {
           activations.push(plaitElement);
+        } else if (
+          element.type === "rectangle" &&
+          element?.subtype === "note"
+        ) {
+          notes.push(plaitElement);
         } else {
           elements.push(plaitElement);
         }
@@ -126,6 +132,7 @@ export const sequenceToDrawnixConvertor = new GraphConverter({
         );
       });
     }
+    elements.push(...notes);
 
     if (chart.groups) {
       chart.groups.forEach((group) => {

--- a/tests/sequence-layering.test.ts
+++ b/tests/sequence-layering.test.ts
@@ -1,0 +1,96 @@
+import { Node as SlateNode } from "slate";
+import { sequenceToDrawnixConvertor } from "../src/converter/types/sequence.js";
+import type { Sequence } from "../src/parser/sequence.js";
+
+const getText = (element: any) => {
+  if (element.text) {
+    return SlateNode.string(element.text);
+  }
+  if (element.texts) {
+    return element.texts
+      .map((text: { text: any }) => SlateNode.string(text.text))
+      .join(" ");
+  }
+  return "";
+};
+
+describe("sequenceToDrawnixConvertor", () => {
+  beforeAll(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () =>
+        ({
+          font: "",
+          measureText: (text: string) => ({
+            width: text.length * 8,
+            actualBoundingBoxAscent: 12,
+            actualBoundingBoxDescent: 4,
+          }),
+        } as any)
+    );
+  });
+
+  it("keeps sequence notes above background highlights and lifelines", () => {
+    const chart: Sequence = {
+      type: "sequence",
+      nodes: [
+        [
+          {
+            type: "rectangle",
+            x: 0,
+            y: 0,
+            width: 240,
+            height: 160,
+            label: { text: "", fontSize: 16 },
+            bgColor: "#fff0e6",
+            subtype: "highlight",
+          },
+        ],
+        [
+          {
+            type: "rectangle",
+            x: 80,
+            y: 40,
+            width: 120,
+            height: 32,
+            label: { text: "Preparing Phase", fontSize: 16 },
+            subtype: "note",
+          },
+        ],
+      ],
+      lines: [
+        {
+          type: "line",
+          startX: 120,
+          startY: 0,
+          endX: 120,
+          endY: 160,
+          strokeColor: "#adb5bd",
+        },
+      ],
+      arrows: [],
+      loops: undefined,
+      groups: [],
+    };
+
+    const { elements } = sequenceToDrawnixConvertor.convert(chart, {
+      fontSize: 20,
+    });
+
+    const backgroundIndex = elements.findIndex(
+      (element: any) => element.fill === "#fff0e6"
+    );
+    const lineIndex = elements.findIndex(
+      (element: any) =>
+        element.type === "arrow-line" && element.strokeColor === "#adb5bd"
+    );
+    const noteIndex = elements.findIndex(
+      (element) => getText(element) === "Preparing Phase"
+    );
+
+    expect(backgroundIndex).toBeGreaterThanOrEqual(0);
+    expect(lineIndex).toBeGreaterThanOrEqual(0);
+    expect(noteIndex).toBeGreaterThanOrEqual(0);
+    expect(backgroundIndex).toBeLessThan(lineIndex);
+    expect(lineIndex).toBeLessThan(noteIndex);
+  });
+});


### PR DESCRIPTION
## Summary

This fixes the sequence diagram layering issue reported from Drawnix in plait-board/drawnix#363.

The change is intentionally narrow: sequence `note` rectangles are collected and appended after lifelines/arrows are converted, so Drawnix renders notes above the lines that pass through the same area. It does not attempt to broadly reorder other sequence elements or change unrelated diagram behavior.

## Root cause

Drawnix renders elements according to their array order. In the sequence converter, note rectangles were emitted before lifelines and message lines, so those lines could render above note boxes.

## Test coverage

Added a minimal regression test that only covers the reported layering relationship:

- background highlight renders below a lifeline
- lifeline renders below a sequence note

## Validation

- `npx vitest run`
- `npm run build`
- Installed a local packed build into Drawnix and verified the issue #363 sample renders correctly in `localhost:4300`
- `npm run build:web` in Drawnix

Refs plait-board/drawnix#363.
